### PR TITLE
Arbeitszeit pro Woche / Gehen

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,12 +50,6 @@
 				<input type="text" class="cometimestext" id="cometimestext2" placeholder="10:00" />
 				<input type="text" class="cometimestext" id="cometimestext3" placeholder="16:00" />
 			</fieldset>
-			<fieldset name="leavetimes">
-				<legend class="hastooltip">Gehen (?)<span class="tooltip">Werte werden zufällig in der Spalte "Gehen" der Tabelle bei Tagen mit Arbeitszeit eingetragen. Sind keine vorhanden bleibt die Spalte leer.</span></legend>
-				<input type="text" class="leavetimestext" id="leavetimestext1" placeholder="17:00" />
-				<input type="text" class="leavetimestext" id="leavetimestext2" placeholder="18:00" />
-				<input type="text" class="leavetimestext" id="leavetimestext3" placeholder="23:00" />
-			</fieldset>
 			<fieldset name="bemerkungen">
 				<legend class="hastooltip">Bemerkungen (?)<span class="tooltip">Werte werden zufällig in der Spalte "Bemerkungen" der Tabelle bei Tagen mit Arbeitszeit eingetragen. Sind keine vorhanden bleibt die Spalte leer.</span></legend>
 				<input type="text" class="bemerkungstext" id="commenttext1" placeholder="Burger braten" />

--- a/stuff.js
+++ b/stuff.js
@@ -286,7 +286,7 @@ function getMondays(month, year) {
 	}
 
 	// save this and all other mondays
-	while (date.getMonth() === month) { // skipping mondays after the 28th, as partial weeks are stupid -- ohh no, you don't
+	while (date.getMonth() === month) {
 		mondays.push(date.getDate() - 1); // -1 because final date list is zero-indexed
 		date.setDate(date.getDate() + 7);
 	}


### PR DESCRIPTION
Hey Kilian,
da ich vor ein paar Wochen 9 Arbeitszeitennachweise rückwirkend ausfüllen musste habe ich mich mal um die Verteilung für Arbeitszeiten pro Woche gekümmert. Die Arbeitszeiten sollten damit für angebrochene Wochen am Monatsanfang und -ende aufgeteilt werden.
Außerdem ist mir aufgefallen, dass die Zeiten für Kommen und gehen nicht die Arbeitszeiten beachten, die Zeit fürs Gehen berechnet sich nun einfach aus Kommen + Arbeitszeit + random Pause in der Mittagszeit.

> fixed weekly dist and 'gehenzeit'
> - partial weeks considered in beginning and end of month
> - partial weeks are filled with hours relative to checked days of week part
> - times to come and go had no relation: changed to consider distribution
> - removed 'gehen' as input
> - added random lunch/break time around noon
