### PR TITLE
Fix total hour computation for fractional hours

### DIFF
--- a/stuff.js
+++ b/stuff.js
@@ -204,7 +204,7 @@ function calculateTotal() {
 
 	for (var i = 0; i <= zellen.length - 1; i++) {
 		var hours = zellen[i].value;
-		hours = parseFloat(hours);
+		hours = parseFloat(hours.replace(',', '.'));
 		if (isNaN(hours)) {
 			continue;
 		}

--- a/stuff.js
+++ b/stuff.js
@@ -210,7 +210,7 @@ function calculateTotal() {
 		}
 		total += hours;
 	}
-	gesamtzahl[0].value = total;
+	gesamtzahl[0].value = total.toLocaleString("de-DE", {maximumFractionDigits: 2});
 }
 
 function getDist(days) {


### PR DESCRIPTION
~A side effect is that total hours is now always formatted as `X,YY`, even if `YY = 00` but that shouldn't be a problem.~ Fixed, using `toLocaleString` allows setting an upper bound without always forcing at least two fractional digits.